### PR TITLE
Use unix-compat instead of unix to support Windows

### DIFF
--- a/metrics.cabal
+++ b/metrics.cabal
@@ -61,10 +61,10 @@ library
                        primitive,
                        mwc-random,
                        transformers-base,
-                       unix,
                        vector-algorithms,
                        containers,
                        time,
+                       unix-compat,
                        lens,
                        ansi-terminal,
                        bytestring
@@ -81,7 +81,6 @@ test-suite             tests
                        async,
                        mwc-random,
                        HUnit,
-                       unix,
                        QuickCheck,
                        primitive,
                        lens

--- a/src/Data/Metrics/Reservoir/ExponentiallyDecaying.hs
+++ b/src/Data/Metrics/Reservoir/ExponentiallyDecaying.hs
@@ -32,7 +32,7 @@ import Data.Metrics.Snapshot (Snapshot(..), takeSnapshot)
 import Data.Primitive.MutVar
 import qualified Data.Vector.Unboxed as V
 import Data.Word
-import System.Posix.Time
+import System.PosixCompat.Time
 import System.Posix.Types
 import System.Random.MWC
 


### PR DESCRIPTION
Use unix-compat instead of unix in library dependency and remove unused unix dependency in test-suite.